### PR TITLE
Update to release v0.8.0 as ingenerator/kohana-dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## v0.8.0 (2018-02-20)
+
+* Rename package to ingenerator/kohana-dependencies 
 * Improve the exception messages provided for easier debugging
 * Fix build and drop support for PHP <=5.5
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,16 @@
 
 A simple dependency injection container for Kohana 3.3.x
 
-- **Author**: Jeremy Lindblom ([jeremeamia](https://github.com/jeremeamia))
-- **Version**: 0.7
+[![Build Status](https://travis-ci.org/ingenerator/kohana-dependencies.svg?branch=0.8.x)](https://travis-ci.org/ingenerator/kohana-dependencies)
+
+
+- **Version**: 0.8
+- **Author**: Andrew Coulton ([acoulton](https://github.com/acoulton))
+
+Forked from original version:
+- **Original Author**: Lorenzo Pisani ([zeelot3k](http://zeelot3k.com))
+- **Original Author**: Jeremy Lindblom ([jeremeamia](https://github.com/jeremeamia))
+
 
 ## About Dependency Injection and Dependency Injection Containers
 

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,17 @@
 {
-	"name":        "zeelot/kohana-dependencies",
+	"name":        "ingenerator/kohana-dependencies",
 	"type":        "library",
 	"description": "A Dependency Injection Container Module for Kohana 3.x",
-	"homepage":    "https://github.com/Zeelot/kohana-dependencies",
+	"homepage":    "https://github.com/ingenerator/kohana-dependencies",
 	"license":     "BSD-3-Clause",
 	"keywords":    ["kohana", "dependencies", "dependency"],
 	"authors": [
+		{
+			"name":     "Andrew Coulton",
+			"email":    "andrew@ingenerator.com",
+			"homepage": "http://www.ingenerator.com",
+			"role":     "developer"
+		},
 		{
 			"name":     "Lorenzo Pisani",
 			"email":    "zeelot3k@gmail.com",
@@ -20,8 +26,8 @@
 		}
 	],
 	"support": {
-		"issues":   "https://github.com/Zeelot/kohana-dependencies/issues",
-		"source":   "https://github.com/Zeelot/kohana-dependencies"
+		"issues":   "https://github.com/ingenerator/kohana-dependencies/issues",
+		"source":   "https://github.com/ingenerator/kohana-dependencies"
 	},
 	"require": {
 		"composer/installers": "~1.0",


### PR DESCRIPTION
Change the package name for our fork and prepare for release.