### PR TITLE
Provide replacement v0.7.1 as ingenerator/kohana-dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## Unreleased
+
+## v0.7.1
+
+* Fully compatible replacement package named as ingnerator/kohana-dependencies
+
+## v0.7.0
+ 
+* The original version forked from zeelot/kohana-dependencies

--- a/README.md
+++ b/README.md
@@ -2,8 +2,16 @@
 
 A simple dependency injection container for Kohana 3.3.x
 
-- **Author**: Jeremy Lindblom ([jeremeamia](https://github.com/jeremeamia))
+[![Build Status](https://travis-ci.org/ingenerator/kohana-dependencies.svg?branch=0.7.x)](https://travis-ci.org/ingenerator/kohana-dependencies)
+
+
 - **Version**: 0.7
+- **Author**: Andrew Coulton ([acoulton](https://github.com/acoulton))
+
+Forked from original version:
+- **Original Author**: Lorenzo Pisani ([zeelot3k](http://zeelot3k.com))
+- **Original Author**: Jeremy Lindblom ([jeremeamia](https://github.com/jeremeamia))
+
 
 ## About Dependency Injection and Dependency Injection Containers
 

--- a/composer.json
+++ b/composer.json
@@ -1,44 +1,50 @@
 {
-	"name":        "zeelot/kohana-dependencies",
-	"type":        "library",
-	"description": "A Dependency Injection Container Module for Kohana 3.x",
-	"homepage":    "https://github.com/Zeelot/kohana-dependencies",
-	"license":     "BSD-3-Clause",
-	"keywords":    ["kohana", "dependencies", "dependency"],
-	"authors": [
-		{
-			"name":     "Lorenzo Pisani",
-			"email":    "zeelot3k@gmail.com",
-			"homepage": "http://zeelot3k.com",
-			"role":     "developer"
-		},
-		{
-			"name":     "Jeremy Lindblom",
-			"email":    "jeremeamia@gmail.com",
-			"homepage": "https://github.com/jeremeamia",
-			"role":     "developer"
-		}
-	],
-	"support": {
-		"issues":   "https://github.com/Zeelot/kohana-dependencies/issues",
-		"source":   "https://github.com/Zeelot/kohana-dependencies"
-	},
-	"require": {
-		"composer/installers": "~1.0",
-		"kohana/core":         ">=3.3",
-		"php":                 ">=5.3.3"
-	},
-	"require-dev": {
-		"kohana/koharness":       "dev-master",
-		"phpspec/phpspec":        "dev-master",
-		"bossa/phpspec2-expect":  "dev-master",
-		"mikey179/vfsStream":     "~1.3"
-	},
-	"extra": {
-		"branch-alias": {
-			"dev-0.5/develop": "0.5.x-dev",
-			"dev-0.6/develop": "0.6.x-dev",
-			"dev-0.7/develop": "0.7.x-dev"
-		}
-	}
+  "name": "ingenerator/kohana-dependencies",
+  "type": "library",
+  "description": "A Dependency Injection Container Module for Kohana 3.x",
+  "homepage": "https://github.com/ingenerator/kohana-dependencies",
+  "license": "BSD-3-Clause",
+  "keywords": [
+    "kohana",
+    "dependencies",
+    "dependency"
+  ],
+  "authors": [
+    {
+      "name": "Andrew Coulton",
+      "email": "andrew@ingenerator.com",
+      "homepage": "http://www.ingenerator.com",
+      "role": "developer"
+    },
+    {
+      "name": "Lorenzo Pisani",
+      "email": "zeelot3k@gmail.com",
+      "homepage": "http://zeelot3k.com",
+      "role": "developer"
+    },
+    {
+      "name": "Jeremy Lindblom",
+      "email": "jeremeamia@gmail.com",
+      "homepage": "https://github.com/jeremeamia",
+      "role": "developer"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/ingenerator/kohana-dependencies/issues",
+    "source": "https://github.com/ingenerator/kohana-dependencies"
+  },
+  "replace": {
+    "zeelot/kohana-dependencies": "self.version"
+  },
+  "require": {
+    "composer/installers": "~1.0",
+    "kohana/core": ">=3.3",
+    "php": ">=5.3.3"
+  },
+  "require-dev": {
+    "kohana/koharness": "dev-master",
+    "phpspec/phpspec": "dev-master",
+    "bossa/phpspec2-expect": "dev-master",
+    "mikey179/vfsStream": "~1.3"
+  }
 }


### PR DESCRIPTION
Exactly compatible with the zeelot version but allows our
releases to show up as a drop-in replacement.